### PR TITLE
filter unique bus stops based on BusStopCode before applying distance…

### DIFF
--- a/NotionReminderService/Services/BotHandlers/TransportHandler/TransportService.cs
+++ b/NotionReminderService/Services/BotHandlers/TransportHandler/TransportService.cs
@@ -31,7 +31,11 @@ public class TransportService(
         int page = 1)
     {
         var busStops = await transportRepository.GetBusStops();
-        var filteredBusStops = busStops
+        var uniqueBusStops = busStops
+            .GroupBy(stop => stop.BusStopCode)
+            .Select(g => g.First())
+            .ToList();
+        var filteredBusStops = uniqueBusStops
             .Where(stop => LocationUtil.HaversineDistance(latitude, longitude, stop.Latitude, stop.Longitude) <= radius)
             .ToList();
 


### PR DESCRIPTION
This pull request improves the way bus stops are filtered by ensuring that only unique bus stops (based on `BusStopCode`) are considered before applying the distance filter. This change helps prevent duplicate bus stops from being processed in subsequent logic.

- **Bus stop deduplication and filtering:**
  * In `TransportService.cs`, the method `UpdateBusStops` now groups bus stops by `BusStopCode` and selects the first entry from each group to ensure uniqueness before filtering them by distance.… criteria